### PR TITLE
Update metadata

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -28,6 +28,7 @@
 		<link href="onix.xml" media-type="application/xml" properties="onix" rel="record"/>
 		<dc:title id="title">Bashan and I</dc:title>
 		<meta property="file-as" refines="#title">Bashan and I</meta>
+		<meta property="dcterms:alternative" refines="#title">A Man and His Dog</meta>
 		<dc:subject id="subject-1">Dogs -- Anecdotes</dc:subject>
 		<meta property="authority" refines="#subject-1">LCSH</meta>
 		<meta property="term" refines="#subject-1">sh2008102348</meta>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -44,6 +44,7 @@
 		<meta property="se:production-notes">A few ending dots and italics that were missing in the Gutenberg transcription were re-added by checking against the print version scanned.</meta>
 		<meta property="se:word-count">38286</meta>
 		<meta property="se:reading-ease.flesch">61.29</meta>
+		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/A_Man_and_His_Dog_(narrative)</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/thomas-mann_bashan-and-i_herman-george-scheffauer</meta>
 		<dc:creator id="author">Thomas Mann</dc:creator>
 		<meta property="file-as" refines="#author">Mann, Thomas</meta>


### PR DESCRIPTION
Two changes proposed here:
- adding the Wikipedia link for this work; and
- adding the alternate title _A Man and His Dog_, which was used in Helen Tracy Lowe-Porter's translation (published after the translation used in this release).